### PR TITLE
perf: fix blocking subprocess in async context + add public_key index

### DIFF
--- a/home/telegram-bot/database.py
+++ b/home/telegram-bot/database.py
@@ -104,6 +104,8 @@ class Database:
                         ON clients(chat_id);
                     CREATE INDEX IF NOT EXISTS idx_devices_client_id
                         ON devices(client_id);
+                    CREATE INDEX IF NOT EXISTS idx_devices_public_key
+                        ON devices(public_key);
                     CREATE INDEX IF NOT EXISTS idx_domain_requests_chat_id
                         ON domain_requests(chat_id);
                     CREATE INDEX IF NOT EXISTS idx_domain_requests_status
@@ -170,6 +172,11 @@ class Database:
                 dev_cols = {r[1] for r in conn.execute("PRAGMA table_info(devices)")}
                 if "is_router" not in dev_cols:
                     conn.execute("ALTER TABLE devices ADD COLUMN is_router INTEGER NOT NULL DEFAULT 0")
+                    conn.commit()
+                # Миграция: добавить индекс на public_key если отсутствует
+                existing_indexes = {r[1] for r in conn.execute("PRAGMA index_list(devices)")}
+                if "idx_devices_public_key" not in existing_indexes:
+                    conn.execute("CREATE INDEX IF NOT EXISTS idx_devices_public_key ON devices(public_key)")
                     conn.commit()
                 logger.info("БД инициализирована")
             finally:

--- a/home/watchdog/watchdog.py
+++ b/home/watchdog/watchdog.py
@@ -571,14 +571,14 @@ async def _measure_throughput(url: str, proxy: str = "", interface: str = "") ->
     return 0.0
 
 
-def _get_active_tun() -> str:
+async def _get_active_tun() -> str:
     """Вернуть имя активного tun-интерфейса, или '' для direct_mode (zapret) и при ошибке."""
     try:
         plugin = plugins.get(state.active_stack)
         if not plugin or plugin.meta.get("direct_mode"):
             return ""   # zapret: нет tun, трафик идёт напрямую
         tun = plugin.meta.get("tun_name", f"tun-{state.active_stack}")
-        rc = subprocess.run(["ip", "link", "show", tun], capture_output=True).returncode
+        rc, _, _ = await run_cmd(["ip", "link", "show", tun], timeout=5)
         return tun if rc == 0 else ""
     except Exception:
         return ""
@@ -586,7 +586,7 @@ def _get_active_tun() -> str:
 
 async def speedtest_small() -> float:
     """100KB тест через активный стек. Возвращает Mbps."""
-    tun = _get_active_tun()
+    tun = await _get_active_tun()
     mbps = await _measure_throughput(SPEED_URL_SMALL, interface=tun)
     if mbps > 0:
         state.small_speedtest.append(mbps)
@@ -596,7 +596,7 @@ async def speedtest_small() -> float:
 
 async def speedtest_large() -> float:
     """10MB тест через активный стек. Возвращает Mbps."""
-    tun = _get_active_tun()
+    tun = await _get_active_tun()
     mbps = await _measure_throughput(SPEED_URL_LARGE, interface=tun)
     if mbps > 0:
         state.large_speedtest.append(mbps)
@@ -605,7 +605,7 @@ async def speedtest_large() -> float:
 
 async def speedtest_upload() -> float:
     """100KB upload-тест через активный стек. Возвращает Mbps."""
-    tun = _get_active_tun()
+    tun = await _get_active_tun()
     tmp = "/tmp/wdg_upload_100k.bin"
     # Генерируем 100KB случайных данных
     rc, _, _ = await run_cmd(


### PR DESCRIPTION
- watchdog: _get_active_tun() called subprocess.run() (blocking) from async speedtest functions, stalling the event loop for up to 35s. Converted to async using run_cmd() (asyncio.create_subprocess_exec).

- database: add idx_devices_public_key index on devices(public_key). Watchdog calls _lookup_peer_device(pubkey) every 10 min per WG peer via WHERE public_key = ?, which previously required a full table scan. Migration creates the index on existing databases automatically.

https://claude.ai/code/session_01B3QNJyQ4j4dfQJkhL2ViC9